### PR TITLE
Add Jest setup

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+};
+
+export default config;

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
 		"lint": "biome lint . --write",
 		"format": "biome format . --write",
 		"check": "biome check . --write",
-		"type-check": "tsc --noEmit",
-		"prepare": "husky"
-	},
+               "type-check": "tsc --noEmit",
+               "prepare": "husky",
+               "test": "jest"
+       },
 	"dependencies": {
 		"@google/generative-ai": "^0.24.1",
 		"@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -37,7 +38,12 @@
 		"@types/react-dom": "^19",
 		"husky": "^9.1.7",
 		"tailwindcss": "^4",
-		"tw-animate-css": "^1.3.5",
-		"typescript": "^5"
-	}
+               "tw-animate-css": "^1.3.5",
+               "typescript": "^5",
+               "@testing-library/jest-dom": "^6.1.0",
+               "@testing-library/react": "^14.1.0",
+               "@types/jest": "^29.5.10",
+               "jest": "^29.7.0",
+               "ts-jest": "^29.1.1"
+       }
 }


### PR DESCRIPTION
## Summary
- add Jest, Testing Library, and ts-jest dev dependencies
- configure Jest with `jest.config.ts`
- include a setup file for `@testing-library/jest-dom`
- expose `test` script in `package.json`

## Testing
- `bun run lint` *(fails: biome not installed)*
- `bun run test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6882ba6107b08320965c0a6c5f7c5fe4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running tests with Jest, including TypeScript and browser-like environment setup.
  * Enhanced test assertions for DOM elements with improved matchers.

* **Chores**
  * Introduced new testing-related dependencies and a test script to streamline running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->