### PR TITLE
Add Jest tests for YouTube library

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,12 +1,12 @@
 import type { Config } from "jest";
 
 const config: Config = {
-  preset: "ts-jest",
-  testEnvironment: "jsdom",
-  moduleNameMapper: {
-    "^@/(.*)$": "<rootDir>/src/$1",
-  },
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+	preset: "ts-jest",
+	testEnvironment: "jsdom",
+	moduleNameMapper: {
+		"^@/(.*)$": "<rootDir>/src/$1",
+	},
+	setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
 		"lint": "biome lint . --write",
 		"format": "biome format . --write",
 		"check": "biome check . --write",
-               "type-check": "tsc --noEmit",
-               "prepare": "husky",
-               "test": "jest"
-       },
+		"type-check": "tsc --noEmit",
+		"prepare": "husky",
+		"test": "jest"
+	},
 	"dependencies": {
 		"@google/generative-ai": "^0.24.1",
 		"@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -38,12 +38,12 @@
 		"@types/react-dom": "^19",
 		"husky": "^9.1.7",
 		"tailwindcss": "^4",
-               "tw-animate-css": "^1.3.5",
-               "typescript": "^5",
-               "@testing-library/jest-dom": "^6.1.0",
-               "@testing-library/react": "^14.1.0",
-               "@types/jest": "^29.5.10",
-               "jest": "^29.7.0",
-               "ts-jest": "^29.1.1"
-       }
+		"tw-animate-css": "^1.3.5",
+		"typescript": "^5",
+		"@testing-library/jest-dom": "^6.1.0",
+		"@testing-library/react": "^14.1.0",
+		"@types/jest": "^29.5.10",
+		"jest": "^29.7.0",
+		"ts-jest": "^29.1.1"
+	}
 }

--- a/src/__tests__/lib/youtube.test.ts
+++ b/src/__tests__/lib/youtube.test.ts
@@ -1,0 +1,79 @@
+jest.mock("googleapis", () => {
+	const mockPlaylistsList = jest.fn();
+	const mockPlaylistItemsList = jest.fn();
+	return {
+		google: {
+			auth: {
+				OAuth2: jest.fn().mockImplementation(() => ({
+					setCredentials: jest.fn(),
+				})),
+			},
+			youtube: jest.fn().mockImplementation(() => ({
+				playlists: { list: mockPlaylistsList },
+				playlistItems: { list: mockPlaylistItemsList },
+			})),
+		},
+		__mockPlaylistsList: mockPlaylistsList,
+		__mockPlaylistItemsList: mockPlaylistItemsList,
+	};
+});
+
+jest.mock("google-auth-library", () => ({ OAuth2Client: jest.fn() }));
+
+import { getPlaylists, getVideosForPlaylist } from "@/lib/youtube";
+import { google } from "googleapis";
+
+const {
+	__mockPlaylistsList: mockPlaylistsList,
+	__mockPlaylistItemsList: mockPlaylistItemsList,
+} = google as unknown as {
+	__mockPlaylistsList: jest.Mock;
+	__mockPlaylistItemsList: jest.Mock;
+};
+
+describe("youtube library", () => {
+	beforeEach(() => {
+		mockPlaylistsList.mockReset();
+		mockPlaylistItemsList.mockReset();
+	});
+
+	describe("getPlaylists", () => {
+		it("returns playlist items", async () => {
+			const items = [{ id: "1" }];
+			mockPlaylistsList.mockResolvedValue({ data: { items } });
+
+			await expect(getPlaylists("token")).resolves.toEqual(items);
+			expect(mockPlaylistsList).toHaveBeenCalledWith({
+				mine: true,
+				part: ["snippet", "contentDetails"],
+				maxResults: 50,
+			});
+		});
+
+		it("throws on API error", async () => {
+			mockPlaylistsList.mockRejectedValue(new Error("fail"));
+
+			await expect(getPlaylists("token")).rejects.toThrow("fail");
+		});
+	});
+
+	describe("getVideosForPlaylist", () => {
+		it("returns playlist videos", async () => {
+			const items = [{ id: "v1" }];
+			mockPlaylistItemsList.mockResolvedValue({ data: { items } });
+
+			await expect(getVideosForPlaylist("token", "pl")).resolves.toEqual(items);
+			expect(mockPlaylistItemsList).toHaveBeenCalledWith({
+				playlistId: "pl",
+				part: ["snippet"],
+				maxResults: 50,
+			});
+		});
+
+		it("throws on API error", async () => {
+			mockPlaylistItemsList.mockRejectedValue(new Error("oops"));
+
+			await expect(getVideosForPlaylist("token", "pl")).rejects.toThrow("oops");
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- add tests for YouTube helper functions

## Testing
- `bun run lint`
- `bun run test` *(fails: ts-node missing)*

------
https://chatgpt.com/codex/tasks/task_e_6882bbf00e988320b6886fe49257e539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new tests to verify YouTube playlist and video retrieval functionality, including handling of successful responses and error cases.

* **Style**
  * Reformatted indentation in configuration and package files for improved readability; no changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->