### PR TITLE
Add playlists route tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import('jest').Config} */
+module.exports = {
+	preset: "ts-jest",
+	testEnvironment: "jsdom",
+	moduleNameMapper: {
+		"^@/(.*)$": "<rootDir>/src/$1",
+	},
+	setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"check": "biome check . --write",
 		"type-check": "tsc --noEmit",
 		"prepare": "husky",
-		"test": "jest"
+		"test": "jest --config jest.config.js"
 	},
 	"dependencies": {
 		"@google/generative-ai": "^0.24.1",

--- a/src/__tests__/api/playlists-route.test.ts
+++ b/src/__tests__/api/playlists-route.test.ts
@@ -1,0 +1,63 @@
+jest.mock("next/server", () => {
+	class MockNextResponse {
+		status: number;
+		private body: string;
+		private parsed?: unknown;
+		constructor(body: string, init?: { status?: number }) {
+			this.body = body;
+			this.status = init?.status ?? 200;
+		}
+		static json(data: unknown) {
+			const res = new MockNextResponse(JSON.stringify(data));
+			res.parsed = data;
+			return res;
+		}
+		json() {
+			return Promise.resolve(this.parsed ?? JSON.parse(this.body));
+		}
+		text() {
+			return Promise.resolve(
+				this.parsed ? JSON.stringify(this.parsed) : this.body,
+			);
+		}
+	}
+	return { NextResponse: MockNextResponse };
+});
+
+const mockAuth = jest.fn();
+const mockGetPlaylists = jest.fn();
+jest.mock("@/lib/auth", () => ({
+	__esModule: true,
+	auth: (...args: unknown[]) => mockAuth(...args),
+}));
+jest.mock("@/lib/youtube", () => ({
+	__esModule: true,
+	getPlaylists: (...args: unknown[]) => mockGetPlaylists(...args),
+}));
+
+let GET: typeof import("@/app/api/youtube/playlists/route").GET;
+
+beforeEach(async () => {
+	jest.resetModules();
+	jest.clearAllMocks();
+	GET = (await import("@/app/api/youtube/playlists/route")).GET;
+});
+
+describe("playlists route GET", () => {
+	it("returns 401 when not authorized", async () => {
+		mockAuth.mockResolvedValue(null);
+		const res = await GET();
+		expect(res.status).toBe(401);
+		await expect(res.text()).resolves.toBe("Unauthorized");
+	});
+
+	it("returns playlists when authorized", async () => {
+		mockAuth.mockResolvedValue({ accessToken: "token" });
+		const playlists = [{ id: "1" }];
+		mockGetPlaylists.mockResolvedValue(playlists);
+		const res = await GET();
+		expect(res.status).toBe(200);
+		await expect(res.json()).resolves.toEqual(playlists);
+		expect(mockGetPlaylists).toHaveBeenCalledWith("token");
+	});
+});


### PR DESCRIPTION
## Summary
- create Jest config in JS
- update test script to use JS config
- add playlists route tests with mocks

## Testing
- `bun run lint`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_6882bbf1066883208584f9c9bd6ed367