### PR TITLE
Add DashboardPage test suite

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,4 @@
-import type { Config } from "jest";
-
-const config: Config = {
+module.exports = {
 	preset: "ts-jest",
 	testEnvironment: "jsdom",
 	moduleNameMapper: {
@@ -8,5 +6,3 @@ const config: Config = {
 	},
 	setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
 };
-
-export default config;

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
 		"lint": "biome lint . --write",
 		"format": "biome format . --write",
 		"check": "biome check . --write",
-               "type-check": "tsc --noEmit",
-               "prepare": "husky",
-               "test": "jest"
-       },
+		"type-check": "tsc --noEmit",
+		"prepare": "husky",
+		"test": "jest --config jest.config.js"
+	},
 	"dependencies": {
 		"@google/generative-ai": "^0.24.1",
 		"@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -38,12 +38,12 @@
 		"@types/react-dom": "^19",
 		"husky": "^9.1.7",
 		"tailwindcss": "^4",
-               "tw-animate-css": "^1.3.5",
-               "typescript": "^5",
-               "@testing-library/jest-dom": "^6.1.0",
-               "@testing-library/react": "^14.1.0",
-               "@types/jest": "^29.5.10",
-               "jest": "^29.7.0",
-               "ts-jest": "^29.1.1"
-       }
+		"tw-animate-css": "^1.3.5",
+		"typescript": "^5",
+		"@testing-library/jest-dom": "^6.1.0",
+		"@testing-library/react": "^14.1.0",
+		"@types/jest": "^29.5.10",
+		"jest": "^29.7.0",
+		"ts-jest": "^29.1.1"
+	}
 }

--- a/src/app/dashboard/__tests__/page.test.tsx
+++ b/src/app/dashboard/__tests__/page.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import DashboardPage from "../page";
+import { useSession } from "next-auth/react";
+
+jest.mock("next-auth/react");
+
+const mockedUseSession = useSession as jest.MockedFunction<typeof useSession>;
+
+describe("DashboardPage", () => {
+	const playlists = [
+		{
+			id: "1",
+			snippet: {
+				title: "My Playlist",
+				thumbnails: { default: { url: "thumb1.jpg", width: 100, height: 100 } },
+			},
+		},
+		{
+			id: "2",
+			snippet: {
+				title: "Another One",
+				thumbnails: { default: { url: "thumb2.jpg", width: 100, height: 100 } },
+			},
+		},
+	];
+
+	const setup = () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		return render(
+			<QueryClientProvider client={queryClient}>
+				<DashboardPage />
+			</QueryClientProvider>,
+		);
+	};
+
+	beforeEach(() => {
+		mockedUseSession.mockReturnValue({ data: { user: {} } } as any);
+		global.fetch = jest.fn(() =>
+			Promise.resolve({
+				ok: true,
+				json: () => Promise.resolve(playlists),
+			} as Response),
+		) as jest.Mock;
+	});
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it("shows loading indicator", async () => {
+		setup();
+		expect(screen.getByText(/loading playlists/i)).toBeInTheDocument();
+		await waitFor(() =>
+			expect(screen.queryByText(/loading playlists/i)).not.toBeInTheDocument(),
+		);
+	});
+
+	it("renders playlists", async () => {
+		setup();
+		expect(await screen.findByText("My Playlist")).toBeInTheDocument();
+		expect(screen.getByText("Another One")).toBeInTheDocument();
+	});
+
+	it("filters playlists by search", async () => {
+		setup();
+		await screen.findByText("My Playlist");
+		const input = screen.getByPlaceholderText(/search playlists/i);
+		fireEvent.change(input, { target: { value: "another" } });
+		expect(screen.queryByText("My Playlist")).not.toBeInTheDocument();
+		expect(screen.getByText("Another One")).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary
- add React Testing Library tests for DashboardPage
- use a JS Jest config to avoid ts-node requirement
- update test script to specify config

## Testing
- `bun run lint`
- `bun run test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6882bbf51388832092b823e350f6bdd4