### PR TITLE
Add tests for analysis route

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,12 +1,12 @@
 import type { Config } from "jest";
 
 const config: Config = {
-  preset: "ts-jest",
-  testEnvironment: "jsdom",
-  moduleNameMapper: {
-    "^@/(.*)$": "<rootDir>/src/$1",
-  },
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+	preset: "ts-jest",
+	testEnvironment: "jsdom",
+	moduleNameMapper: {
+		"^@/(.*)$": "<rootDir>/src/$1",
+	},
+	setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
 		"lint": "biome lint . --write",
 		"format": "biome format . --write",
 		"check": "biome check . --write",
-               "type-check": "tsc --noEmit",
-               "prepare": "husky",
-               "test": "jest"
-       },
+		"type-check": "tsc --noEmit",
+		"prepare": "husky",
+		"test": "jest"
+	},
 	"dependencies": {
 		"@google/generative-ai": "^0.24.1",
 		"@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -38,12 +38,12 @@
 		"@types/react-dom": "^19",
 		"husky": "^9.1.7",
 		"tailwindcss": "^4",
-               "tw-animate-css": "^1.3.5",
-               "typescript": "^5",
-               "@testing-library/jest-dom": "^6.1.0",
-               "@testing-library/react": "^14.1.0",
-               "@types/jest": "^29.5.10",
-               "jest": "^29.7.0",
-               "ts-jest": "^29.1.1"
-       }
+		"tw-animate-css": "^1.3.5",
+		"typescript": "^5",
+		"@testing-library/jest-dom": "^6.1.0",
+		"@testing-library/react": "^14.1.0",
+		"@types/jest": "^29.5.10",
+		"jest": "^29.7.0",
+		"ts-jest": "^29.1.1"
+	}
 }

--- a/src/app/api/analysis-route.test.ts
+++ b/src/app/api/analysis-route.test.ts
@@ -1,0 +1,84 @@
+import type { NextRequest } from "next/server";
+
+jest.mock("@/lib/auth", () => ({
+	auth: jest.fn(),
+}));
+
+jest.mock("googleapis", () => ({
+	google: {
+		youtube: jest.fn(),
+	},
+}));
+
+jest.mock("@/lib/gemini", () => ({
+	generativeModel: {
+		generateContent: jest.fn(),
+	},
+}));
+
+const { auth } = require("@/lib/auth");
+const { google } = require("googleapis");
+const { generativeModel } = require("@/lib/gemini");
+
+describe("POST /api/analysis", () => {
+	beforeEach(() => {
+		jest.resetModules();
+		(auth as jest.Mock).mockReset();
+		(google.youtube as jest.Mock).mockReset();
+		(generativeModel.generateContent as jest.Mock).mockReset();
+	});
+
+	it("returns 401 if no session", async () => {
+		(auth as jest.Mock).mockResolvedValue(null);
+		(google.youtube as jest.Mock).mockReturnValue({
+			videos: { list: jest.fn() },
+		});
+
+		const { POST } = await import("@/app/api/analysis/route");
+		const req = { json: jest.fn() } as unknown as NextRequest;
+
+		const res = await POST(req);
+		expect(res.status).toBe(401);
+		await expect(res.text()).resolves.toBe("Unauthorized");
+	});
+
+	it("returns 400 if videoId missing", async () => {
+		(auth as jest.Mock).mockResolvedValue({});
+		(google.youtube as jest.Mock).mockReturnValue({
+			videos: { list: jest.fn() },
+		});
+
+		const { POST } = await import("@/app/api/analysis/route");
+		const req = {
+			json: jest.fn().mockResolvedValue({}),
+		} as unknown as NextRequest;
+
+		const res = await POST(req);
+		expect(res.status).toBe(400);
+		await expect(res.text()).resolves.toBe("Video ID is required");
+	});
+
+	it("returns analysis json on success", async () => {
+		(auth as jest.Mock).mockResolvedValue({});
+		const mockList = jest.fn().mockResolvedValue({
+			data: {
+				items: [{ snippet: { title: "title", description: "desc" } }],
+			},
+		});
+		(google.youtube as jest.Mock).mockReturnValue({
+			videos: { list: mockList },
+		});
+		(generativeModel.generateContent as jest.Mock).mockResolvedValue({
+			response: { text: () => "analysis text" },
+		});
+
+		const { POST } = await import("@/app/api/analysis/route");
+		const req = {
+			json: jest.fn().mockResolvedValue({ videoId: "123" }),
+		} as unknown as NextRequest;
+
+		const res = await POST(req);
+		expect(res.status).toBe(200);
+		await expect(res.json()).resolves.toEqual({ analysis: "analysis text" });
+	});
+});


### PR DESCRIPTION
## Summary
- add Jest test covering the analysis route
- mock auth, YouTube API and Gemini model

## Testing
- `bun run lint`
- `bun run test` *(fails: ts-node missing)*

------
https://chatgpt.com/codex/tasks/task_e_6882bbf2ddf48320a2e2f38b16d03c51